### PR TITLE
Update community guidelines links for YouTube and Twitch

### DIFF
--- a/src/DotNet.Community.Home/Pages/CodeOfConduct.razor
+++ b/src/DotNet.Community.Home/Pages/CodeOfConduct.razor
@@ -22,7 +22,7 @@
 <MudText Typo=Typo.h5 Class="pb-4">Twitch.TV: Community Guidelines</MudText>
 <MudFab StartIcon=@Icons.Material.Filled.Link Size=Size.Large
     IconSize=Size.Large IconColor=Color.Primary Target="_blank"
-    Href="https://www.twitch.tv/creatorcamp/learn-the-basics/community-guidelines" />
+    Href="https://safety.twitch.tv/s/article/Community-Guidelines" />
 
 <MudDivider Class="my-4" />
 

--- a/src/DotNet.Community.Home/Pages/CodeOfConduct.razor
+++ b/src/DotNet.Community.Home/Pages/CodeOfConduct.razor
@@ -22,11 +22,11 @@
 <MudText Typo=Typo.h5 Class="pb-4">Twitch.TV: Community Guidelines</MudText>
 <MudFab StartIcon=@Icons.Material.Filled.Link Size=Size.Large
     IconSize=Size.Large IconColor=Color.Primary Target="_blank"
-    Href="https://www.youtube.com/howyoutubeworks/policies/community-guidelines" />
+    Href="https://www.twitch.tv/creatorcamp/learn-the-basics/community-guidelines" />
 
 <MudDivider Class="my-4" />
 
 <MudText Typo=Typo.h5 Class="pb-4">YouTube: Community Guidelines</MudText>
 <MudFab StartIcon=@Icons.Custom.Brands.YouTube Size=Size.Large 
     IconSize=Size.Large Color=Color.Error Target="_blank"
-    Href="https://www.twitch.tv/creatorcamp/learn-the-basics/community-guidelines" />
+    Href="https://www.youtube.com/howyoutubeworks/policies/community-guidelines" />


### PR DESCRIPTION
The link we had for Twitch was redirecting to a new location. Use the new community guidelines link there instead.